### PR TITLE
Add support in CacheValidatorIdentifier::__toString() for wider non-scalar types

### DIFF
--- a/src/Model/CacheValidatorIdentifier.php
+++ b/src/Model/CacheValidatorIdentifier.php
@@ -4,6 +4,13 @@ namespace SimplyTestable\PageCacheBundle\Model;
 
 class CacheValidatorIdentifier
 {
+    const BOOL_TRUE_STRING = 'true';
+    const BOOL_FALSE_STRING = 'false';
+    const NULL_STRING = 'null';
+
+    const EXCEPTION_CODE_OBJECT_CANNOT_BE_CONVERTED_TO_STRING = 1;
+    const EXCEPTION_CODE_VALUE_CANNOT_BE_CONVERTED_TO_STRING = 2;
+
     /**
      * @var array
      */
@@ -29,13 +36,48 @@ class CacheValidatorIdentifier
     {
         $keyValuePairs = array();
         foreach ($this->parameters as $key => $value) {
-            if (is_bool($value)) {
-                $value = $value ? 'true' : 'false';
-            }
-
-            $keyValuePairs[] = $key . ':' . $value;
+            $keyValuePairs[] = $key . ':' . $this->convertValueToString($value, $key);
         }
 
         return md5(implode('+', $keyValuePairs));
+    }
+
+    private function convertValueToString($value, $key): string
+    {
+        if (is_bool($value)) {
+            return $value ? self::BOOL_TRUE_STRING : self::BOOL_FALSE_STRING;
+        }
+
+        if (is_null($value)) {
+            return self::NULL_STRING;
+        }
+
+        if (is_scalar($value)) {
+            return (string)$value;
+        }
+
+        if (is_array($value)) {
+            return json_encode($value);
+        }
+
+        if (is_object($value)) {
+            if (method_exists($value, '__toString')) {
+                return (string)$value;
+            }
+
+            if ($value instanceof \JsonSerializable) {
+                return json_encode($value);
+            }
+
+            throw new \UnexpectedValueException(
+                sprintf('Object of type %s cannot be converted to a string', get_class($value)),
+                self::EXCEPTION_CODE_OBJECT_CANNOT_BE_CONVERTED_TO_STRING
+            );
+        }
+
+        throw new \UnexpectedValueException(
+            sprintf('Value with key "%s" cannot be converted to a string', $key),
+            self::EXCEPTION_CODE_VALUE_CANNOT_BE_CONVERTED_TO_STRING
+        );
     }
 }

--- a/tests/Unit/Implementation/ObjectImplementingJsonSerializable.php
+++ b/tests/Unit/Implementation/ObjectImplementingJsonSerializable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SimplyTestable\PageCacheBundle\Tests\Unit\Implementation;
+
+class ObjectImplementingJsonSerializable implements \JsonSerializable
+{
+    /**
+     * @var array
+     */
+    private $values;
+
+    public function __construct(array $values)
+    {
+        $this->values = $values;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->values;
+    }
+}

--- a/tests/Unit/Implementation/ObjectImplementingToString.php
+++ b/tests/Unit/Implementation/ObjectImplementingToString.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace SimplyTestable\PageCacheBundle\Tests\Unit\Implementation;
+
+class ObjectImplementingToString
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    public function __toString(): string
+    {
+        return (string)$this->value;
+    }
+}

--- a/tests/Unit/Model/CacheValidatorIdentifierTest.php
+++ b/tests/Unit/Model/CacheValidatorIdentifierTest.php
@@ -96,7 +96,9 @@ class CacheValidatorIdentifierTest extends TestCase
 
         $this->expectException(\UnexpectedValueException::class);
         $this->expectExceptionCode(CacheValidatorIdentifier::EXCEPTION_CODE_OBJECT_CANNOT_BE_CONVERTED_TO_STRING);
-        $this->expectExceptionMessage('Object of type '. CacheValidatorHeaders::class .' cannot be converted to a string');
+        $this->expectExceptionMessage(
+            'Object of type '. CacheValidatorHeaders::class .' cannot be converted to a string'
+        );
 
         $cacheValidatorIdentifier->__toString();
     }

--- a/tests/Unit/Model/CacheValidatorIdentifierTest.php
+++ b/tests/Unit/Model/CacheValidatorIdentifierTest.php
@@ -3,7 +3,10 @@
 namespace SimplyTestable\PageCacheBundle\Tests\Unit\Model;
 
 use PHPUnit\Framework\TestCase;
+use SimplyTestable\PageCacheBundle\Entity\CacheValidatorHeaders;
 use SimplyTestable\PageCacheBundle\Model\CacheValidatorIdentifier;
+use SimplyTestable\PageCacheBundle\Tests\Unit\Implementation\ObjectImplementingJsonSerializable;
+use SimplyTestable\PageCacheBundle\Tests\Unit\Implementation\ObjectImplementingToString;
 
 class CacheValidatorIdentifierTest extends TestCase
 {
@@ -45,19 +48,19 @@ class CacheValidatorIdentifierTest extends TestCase
     }
 
     /**
-     * @dataProvider castToStringDataProvider
+     * @dataProvider castToStringSuccessDataProvider
      *
      * @param array $parameters
      * @param string $expectedStringRepresentation
      */
-    public function testCastToString(array $parameters, string $expectedStringRepresentation)
+    public function testCastToStringSuccess(array $parameters, string $expectedStringRepresentation)
     {
         $cacheValidatorIdentifier = new CacheValidatorIdentifier($parameters);
 
         $this->assertEquals($expectedStringRepresentation, $cacheValidatorIdentifier->__toString());
     }
 
-    public function castToStringDataProvider(): array
+    public function castToStringSuccessDataProvider(): array
     {
         return [
             'no parameters' => [
@@ -66,13 +69,54 @@ class CacheValidatorIdentifierTest extends TestCase
             ],
             'has parameters' => [
                 'parameters' => [
-                    'foo' => true,
-                    'bar' => false,
-                    'int' => 1,
+                    'null' => null,
+                    'bool true' => true,
+                    'bool false' => false,
+                    'scalar int' => 1,
+                    'scalar float' => M_PI,
                     'string' => 'foo',
+                    'array' => [
+                        'a' => 1,
+                        'b' => true,
+                        'c' => 'foo',
+                    ],
+                    'object implementing __toString' => new ObjectImplementingToString(123),
+                    'object implementing jsonSerializable' => new ObjectImplementingJsonSerializable([1, 2, 3, ]),
                 ],
-                'expectedStringRepresentation' => '126d389663284baf69956edd701c9d3e',
+                'expectedStringRepresentation' => 'bc5e57f0c2c360f0eeb430b50146ea47',
             ],
         ];
+    }
+
+    public function testCastToStringInvalidObject()
+    {
+        $cacheValidatorIdentifier = new CacheValidatorIdentifier([
+            'value' => new CacheValidatorHeaders(),
+        ]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionCode(CacheValidatorIdentifier::EXCEPTION_CODE_OBJECT_CANNOT_BE_CONVERTED_TO_STRING);
+        $this->expectExceptionMessage('Object of type '. CacheValidatorHeaders::class .' cannot be converted to a string');
+
+        $cacheValidatorIdentifier->__toString();
+    }
+
+    public function testCastToStringInvalidValue()
+    {
+        $thisFQCNParts = explode('\\', get_class($this));
+        $className = $thisFQCNParts[count($thisFQCNParts) - 1];
+        $thisPath = __DIR__ . '/' . $className . '.php';
+
+        $fileResource = fopen($thisPath, 'r');
+
+        $cacheValidatorIdentifier = new CacheValidatorIdentifier([
+            'key_name' => $fileResource,
+        ]);
+
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionCode(CacheValidatorIdentifier::EXCEPTION_CODE_VALUE_CANNOT_BE_CONVERTED_TO_STRING);
+        $this->expectExceptionMessage('Value with key "key_name" cannot be converted to a string');
+
+        $cacheValidatorIdentifier->__toString();
     }
 }


### PR DESCRIPTION
Fixes #7 